### PR TITLE
fix: Unable to extends property title

### DIFF
--- a/src/multi-lang/titles.storage.ts
+++ b/src/multi-lang/titles.storage.ts
@@ -45,7 +45,13 @@ export function getClassValidatorPropertyTitles(object: object): ClassValidatorP
 
 export function getClassValidatorPropertyTitle(object: object, propertyName: string): string | undefined {
   const titles = getClassValidatorPropertyTitles(object);
-  return titles.get(propertyName);
+  const title = titles.get(propertyName)
+  if (title) return title
+  
+  const proto = Object.getPrototypeOf(object)
+  if (proto && proto !== Object) {
+    return getClassValidatorPropertyTitle(proto, propertyName)
+  }
 }
 
 // CLASS


### PR DESCRIPTION
```ts
import { IsOptional, Equals, ClassPropertyTitle, validator } from 'class-validator-multi-lang';

class Parent {
  @IsOptional()
  @Equals('test')
  @ClassPropertyTitle('property "title"')
  title: string = 'bad_value';
}

class MyClass extends Parent {}

const RU_I18N_MESSAGES = {
  '$property must be equal to $constraint1': '$property должно быть равно $constraint1',
};
const RU_I18N_TITLES = {
  'property "title"': 'поле "заголовок"',
};

const model = new MyClass();

validator.validate(model, { messages: RU_I18N_MESSAGES, titles: RU_I18N_TITLES }).then(errors => {
  console.log(errors[0].constraints);
  // now out: title должно быть равно test
  // expect out: поле "заголовок" должно быть равно test
});
```

